### PR TITLE
Minor Fix to Cleanup Console

### DIFF
--- a/src/dragsort.js
+++ b/src/dragsort.js
@@ -76,9 +76,13 @@ var DragSort = (function (elm) {
         },
 
         getDraggableElm(elm) {
-            var draggableElm = elm.closest('[draggable="true"]')
-            // only allow dragging/dropping inside the same parent element
-            return (this.uid == _current.uid) ? draggableElm : null
+            if(elm.closest) { // `closest` might not be defined on all elements
+                var draggableElm = elm.closest('[draggable="true"]')
+                // only allow dragging/dropping inside the same parent element
+                return (this.uid == _current.uid) ? draggableElm : null
+            } else {
+                return null;
+            }
         },
 
         dragstart(e, elm) {


### PR DESCRIPTION
If you use `dragsort` with `Tagify` and then you double click on a tag to modify it and then drag the tag in edit mode, you'll see the following error in console:

```
Uncaught TypeError: t.closest is not a function
    getDraggableElm file:///chart/assets/js/dragsort.js:1
    dragenter file:///chart/assets/js/dragsort.js:1
    dragenter file:///chart/assets/js/dragsort.js:1
    bindEvents file:///chart/assets/js/dragsort.js:1
    n file:///chart/assets/js/dragsort.js:1
    DragSort file:///chart/assets/js/dragsort.js:1
    <anonymous> file:///chart/index.html#branches[]=master:701
    onload file:///chart/index.html#branches[]=master:1089
    getGZipJSON file:///chart/index.html#branches[]=master:1079
    <anonymous> file:///chart/index.html#branches[]=master:681
    onload file:///chart/index.html#branches[]=master:1089
    getGZipJSON file:///chart/index.html#branches[]=master:1079
    <anonymous> file:///chart/index.html#branches[]=master:622
    jQuery 13
dragsort.js:1:879
```

This fix prevents unnecessary errors in the console.